### PR TITLE
Fix warnings and minor optimizations

### DIFF
--- a/lib/libpe.ex
+++ b/lib/libpe.ex
@@ -99,7 +99,7 @@ defmodule LibPE do
   end
 
   defp parse_coff(
-         pe = %LibPE{},
+         %LibPE{} = pe,
          <<machine::little-size(16), number_of_sections::little-size(16),
            timestamp::little-size(32), object_offset::little-size(32),
            object_entry_count::little-size(32), coff_header_size::little-size(16),
@@ -142,9 +142,7 @@ defmodule LibPE do
 
     number_of_sections = length(sections)
 
-    sections =
-      Enum.map(sections, &LibPE.Section.encode/1)
-      |> Enum.join()
+    sections = Enum.map_join(sections, &LibPE.Section.encode/1)
 
     <<machine::little-size(16), number_of_sections::little-size(16), timestamp::little-size(32),
       object_offset::little-size(32), object_entry_count::little-size(32),

--- a/lib/libpe/checksum.ex
+++ b/lib/libpe/checksum.ex
@@ -3,7 +3,7 @@ defmodule LibPE.Checksum do
     Elixir implementation of the PE checksum algorithm by David N. Cutler 1993
     from https://bytepointer.com/resources/microsoft_pe_checksum_algo_distilled.htm
   """
-  use Bitwise
+  import Bitwise
   @max_word 0xFFFF
   @max_long 0xFFFFFFFF
   @max_long_long 0xFFFFFFFFFFFFFFFF

--- a/lib/libpe/flags.ex
+++ b/lib/libpe/flags.ex
@@ -1,6 +1,6 @@
 defmodule LibPE.Flags do
   @moduledoc false
-  use Bitwise
+  import Bitwise
 
   defmacro __using__(opts) do
     if :many in opts do

--- a/lib/libpe/resource_table.ex
+++ b/lib/libpe/resource_table.ex
@@ -7,7 +7,7 @@ defmodule LibPE.ResourceTable do
       Type > Name > Language
   """
   alias LibPE.ResourceTable
-  use Bitwise
+  import Bitwise
 
   defstruct characteristics: 0,
             timestamp: 0,
@@ -195,7 +195,7 @@ defmodule LibPE.ResourceTable do
            major_version: major_version,
            minor_version: minor_version
          } = table,
-         context = %EncodeContext{}
+         %EncodeContext{} = context
        ) do
     entries = sorted_entries(table)
     number_of_id_entries = Enum.count(entries, fn %DirEntry{name: name} -> is_integer(name) end)
@@ -294,11 +294,11 @@ defmodule LibPE.ResourceTable do
            entry: entry,
            raw_entry: raw_entry
          },
-         context = %EncodeContext{
+         %EncodeContext{
            names: names,
            tables: tables,
            data_entries: data_entries
-         }
+         } = context
        ) do
     {raw_name, context} =
       cond do
@@ -459,9 +459,7 @@ defmodule LibPE.ResourceTable do
 
   defp dump(%DataBlob{data_rva: _data_rva, data: data, codepage: codepage}, level, opts) do
     IO.puts(
-      "#{dup(level)} DATA size: #{byte_size(data)}, codepage: #{
-        inspect(LibPE.Codepage.decode(codepage))
-      }"
+      "#{dup(level)} DATA size: #{byte_size(data)}, codepage: #{inspect(LibPE.Codepage.decode(codepage))}"
     )
 
     cond do

--- a/lib/libpe/section.ex
+++ b/lib/libpe/section.ex
@@ -31,7 +31,7 @@ defmodule LibPE.Section do
            size_of_raw_data::little-size(32), pointer_to_raw_data::little-size(32),
            pointer_to_relocations::little-size(32), pointer_to_linenumbers::little-size(32),
            number_of_relocations::little-size(16), number_of_linenumbers::little-size(16),
-           flags::little-size(32), rest::binary()>>,
+           flags::little-size(32), rest::binary>>,
          full_image
        ) do
     raw_data = binary_part(full_image, pointer_to_raw_data, size_of_raw_data)


### PR DESCRIPTION
Fixes compiler warnings in Elixir >= 1.14.

Also changed one occurrence of `Enum.map/2 |> Enum.join/1` to `Enum.map_join/3` and made the variable name in pattern matching more consistent.